### PR TITLE
Fix blocker preventing ember-observer from tracking an addon's embroider compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,51 @@
+# eslint-plugin-emberobserver
+
+The addon is part of an initiative to implement showing embroider compatibility for addons in emberobserver.
+To check if the addon is embroider compatible there need to be two checks:
+1. check if ember-cli-build.js call maybeEmbroider function
+2. check if tests ember-safe and ember-optimised passed
+
+This addon solves the first point. maybeembroider-required rule will check if maybeEmbroider function is called in ember-cli-build.js
+
+## Installation
+
+You'll first need to install [ESLint](https://eslint.org/):
+
+```sh
+npm i eslint --save-dev
+```
+
+Next, install `eslint-plugin-emberobserver`:
+
+```sh
+npm install eslint-plugin-emberobserver --save-dev
+```
+
+## Usage
+
+Add `emberobserver` to the plugins section of your `.eslintrc` configuration file. You can omit the `eslint-plugin-` prefix:
+
+```json
+{
+    "plugins": [
+        "emberobserver"
+    ]
+}
+```
+
+
+Then configure the rules you want to use under the rules section.
+
+```json
+{
+    "rules": {
+        "emberobserver/maybeembroider-required": "error"
+    }
+}
+```
+
+## Supported Rules
+
+* Fill in provided rules here
+
+

--- a/docs/rules/maybeembroider-required.md
+++ b/docs/rules/maybeembroider-required.md
@@ -1,0 +1,14 @@
+# Require maybeEmbroider function imported and called in ember-cli-build.js (maybeembroider-required)
+
+
+
+## Rule Details
+
+Examples of **correct** code for this rule:
+
+```js
+
+const { maybeEmbroider } = require('@embroider/test-setup');
+return maybeEmbroider(...);
+
+```

--- a/lib/rules/maybeembroider-required.js
+++ b/lib/rules/maybeembroider-required.js
@@ -1,0 +1,134 @@
+/**
+ * @fileoverview Require maybeEmbroider function imported and called in ember-cli-build.js
+ * @author Stanislav Dunajcan
+ */
+"use strict";
+const path = require('path');
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+function isRequireCall(node) {
+  return (
+    node.callee.name === "require" &&
+    node.arguments.length === 1 &&
+    node.arguments[0].value === "@embroider/test-setup"
+  );
+}
+
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+  meta: {
+    messages: {
+      error: "maybeEmbroider isn't called!",
+    },
+    type: "problem", // `problem`, `suggestion`, or `layout`
+    docs: {
+      description:
+        "Require maybeEmbroider function imported and called in ember-cli-build.js",
+      recommended: false,
+      url: null,
+    },
+    fixable: null,
+    schema: [],
+  },
+
+  create(context) {
+    const fullFileName = context.getFilename();
+    const fileName = path.basename(fullFileName);
+    if (fileName !== "ember-cli-build.js") {
+      return {};
+    }
+
+    let funcName;
+    let testSetupName;
+    let resultReturned = false;
+    let resultVariableName;
+
+    function getParentByCondition(node, conditionFunction){
+      if(node.parent){
+        if(conditionFunction(node.parent)){
+          return node.parent;
+        }else{
+          return getParentByCondition(node.parent, conditionFunction);
+        }
+      }
+    }
+
+    function isExportedFunction(node){
+      return node.type === "AssignmentExpression" &&
+        node.left?.object?.name === "module" &&
+        node.left?.property?.name === "exports" &&
+        node.right?.type === 'FunctionExpression';
+    }
+
+    function checkResultReturned(node) {
+      // check if it is inside exported function
+      const exportedFunctionParent = getParentByCondition(node, isExportedFunction);
+      if(!exportedFunctionParent){
+        return;
+      }
+      
+      // check if it is returned
+      switch (node.parent?.type) {
+        case "ReturnStatement":
+          resultReturned = true;
+          break;
+        case "VariableDeclarator":
+          resultVariableName = node.parent?.id?.name;
+          break;
+      }
+    }
+
+    return {
+      CallExpression(node) {
+        // get imported function name
+        if (
+          isRequireCall(node) &&
+          node.parent &&
+          node.parent.type === "VariableDeclarator"
+        ) {
+          if (node.parent.id.type === "Identifier") {
+            testSetupName = node.parent.id.name;
+          } else if (node.parent.id.type === "ObjectPattern") {
+            const prop = node.parent.id.properties.find(
+              (p) => p.key.name === "maybeEmbroider"
+            );
+            if (prop) {
+              funcName = prop.value.name;
+            }
+          }
+        }
+
+        // check maybeEmbroider is called
+        if (funcName) {
+          if (node.callee.name === funcName) {
+            checkResultReturned(node);
+          }
+        } else if (testSetupName) {
+          if (
+            node.callee.object &&
+            node.callee.object.name === testSetupName &&
+            node.callee.property.name === "maybeEmbroider"
+          ) {
+            checkResultReturned(node);
+          }
+        }
+      },
+      ReturnStatement(node){
+        if(resultVariableName && node.argument?.name === resultVariableName){
+          resultReturned = true;
+        }
+      },
+      onCodePathEnd: function (codePath, node) {
+        // at the end of the program checking if maybeEmbroider function was called.
+        if (node.type === "Program" && !resultReturned) {
+          context.report({
+            node,
+            messageId: "error",
+          });
+        }
+      },
+    };  
+  },
+};

--- a/tests/lib/rules/maybeembroider-required.js
+++ b/tests/lib/rules/maybeembroider-required.js
@@ -1,0 +1,149 @@
+/**
+ * @fileoverview Require maybeEmbroider function imported and called in ember-cli-build.js
+ * @author Stanislav Dunajcan
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require("../../../lib/rules/maybeembroider-required"),
+  RuleTester = require("eslint").RuleTester;
+
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+  parserOptions: { ecmaVersion: 2020, sourceType: "module" },
+});
+ruleTester.run("maybeembroider-required", rule, {
+  valid: [
+    {
+      // maybeEmbroider directly returned
+      filename: 'some/path/ember-cli-build.js',
+      code: `
+      const { maybeEmbroider } = require("@embroider/test-setup");
+      module.exports = function (defaults){
+        return maybeEmbroider();
+      }`
+    },
+    {
+      // maybeEmbroider aliased, directly returned
+      filename: 'some/path/ember-cli-build.js',
+      code: `
+      const { maybeEmbroider: me } = require("@embroider/test-setup");
+      module.exports = function (defaults){
+        return me();
+      }`
+    },
+    {
+      // maybeEmbroider from default export directly returned
+      filename: 'some/path/ember-cli-build.js',
+      code: `
+      const testSetup = require("@embroider/test-setup");
+      module.exports = function (defaults){
+        return testSetup.maybeEmbroider();
+      }`
+    },
+    {
+      // maybeEmbroider assigned to result and then returned
+      filename: 'some/path/ember-cli-build.js',
+      code: `
+      const { maybeEmbroider } = require("@embroider/test-setup");
+      module.exports = function (defaults){
+        let result = maybeEmbroider();
+        return result;
+      }`
+    },
+    {
+      filename: 'some/path/ember-cli-build.js',
+      code: `
+      const { maybeEmbroider: me } = require("@embroider/test-setup");
+      module.exports = function (defaults){
+        let result = me();
+        return result;
+      }`
+    },
+    {
+      filename: 'some/path/ember-cli-build.js',
+      code: `
+      const testSetup = require("@embroider/test-setup");
+      module.exports = function (defaults){
+        let result = testSetup.maybeEmbroider();
+        return result;
+      }`
+    },
+    {
+      // other files are not checked
+      filename: 'some/path/some-file.js',
+      code: `const a = 1;`
+    },
+  ],
+
+  invalid: [
+    {
+      // maybeEmbroider imported from different package
+      filename: 'some/path/ember-cli-build.js',
+      code: `
+      const { maybeEmbroider } = require("different-package");
+      module.exports = function (defaults){
+        return maybeEmbroider();
+      }`,
+      errors: ['maybeEmbroider isn\'t called!'],
+    },
+    {
+      // result not returned
+      filename: 'some/path/ember-cli-build.js',
+      code: `
+      const { maybeEmbroider } = require("@embroider/test-setup");
+      module.exports = function (defaults){
+        maybeEmbroider();
+      }`,
+      errors: ['maybeEmbroider isn\'t called!'],
+    },
+    {
+      // something else returned
+      filename: 'some/path/ember-cli-build.js',
+      code: `
+      const { maybeEmbroider } = require("@embroider/test-setup");
+      module.exports = function (defaults){
+        return someOtherFunc();
+      }`,
+      errors: ['maybeEmbroider isn\'t called!'],
+    },
+    {
+      // testSetup imported from different package
+      filename: 'some/path/ember-cli-build.js',
+      code: `
+      const testSetup = require("different-package");
+      module.exports = function (defaults){
+        return testSetup.maybeEmbroider();
+      }`,
+      errors: ['maybeEmbroider isn\'t called!'],
+    },
+    {
+      // maybeEmbroider assigned, but not returned
+      filename: 'some/path/ember-cli-build.js',
+      code: `
+      const testSetup = require("@embroider/test-setup");
+      module.exports = function (defaults){
+        let result = testSetup.maybeEmbroider();
+        return otherResult;
+      }`,
+      errors: ['maybeEmbroider isn\'t called!'],
+    },
+    {
+      // function not exported
+      filename: 'some/path/ember-cli-build.js',
+      code: `
+      const { maybeEmbroider } = require("@embroider/test-setup");
+      function someFunc (defaults){
+        return maybeEmbroider();
+      }`,
+      errors: ['maybeEmbroider isn\'t called!'],
+    },
+  ],
+});


### PR DESCRIPTION
The addon is part of an initiative to implement showing embroider compatibility for addons in emberobserver.
To check if the addon is embroider compatible there need to be two checks:

1. check if ember-cli-build.js call maybeEmbroider function
2. check if tests ember-safe and ember-optimised passed

This addon solves the first point. maybeembroider-required rule will check if maybeEmbroider function is called in ember-cli-build.js